### PR TITLE
fix: ikea_bulb_device_set listener registration crash + ConfigEntryNotReady on connection failure

### DIFF
--- a/custom_components/dirigera_platform/__init__.py
+++ b/custom_components/dirigera_platform/__init__.py
@@ -12,6 +12,8 @@ from .ikea_gateway import ikea_gateway
 import voluptuous as vol
 
 from homeassistant import config_entries, core
+from homeassistant.exceptions import ConfigEntryNotReady
+import requests as _requests
 from homeassistant.components.light import PLATFORM_SCHEMA
 from homeassistant.const import CONF_IP_ADDRESS, CONF_TOKEN, Platform
 
@@ -195,7 +197,12 @@ async def async_setup_entry(
     platform = ikea_gateway()
     hass.data[DOMAIN][PLATFORM] = platform 
     logger.debug("Starting make_devices...")
-    await platform.make_devices(hass,hass_data[CONF_IP_ADDRESS], hass_data[CONF_TOKEN])
+    try:
+        await platform.make_devices(hass,hass_data[CONF_IP_ADDRESS], hass_data[CONF_TOKEN])
+    except (_requests.exceptions.ConnectionError, OSError) as err:
+        raise ConfigEntryNotReady(
+            f"Cannot connect to IKEA Dirigera hub at {hass_data[CONF_IP_ADDRESS]}: {err}"
+        ) from err
     
     #await hass.async_add_executor_job(platform.make_devices,hass, hass_data[CONF_IP_ADDRESS], hass_data[CONF_TOKEN])
 

--- a/custom_components/dirigera_platform/light.py
+++ b/custom_components/dirigera_platform/light.py
@@ -394,7 +394,7 @@ class ikea_bulb_device_set(LightEntity):
     def device_info(self) -> DeviceInfo:
 
         # Register the device for updates
-        hub_event_listener.register(self.unique_id, self)
+        hub_event_listener.register(self.unique_id, registry_entry(self))
         
         return DeviceInfo(
             identifiers={("dirigera_platform", self._device_set.id)},


### PR DESCRIPTION
## Summary

Two related bugs that together caused the Dirigera integration to require ~20 manual reloads before successfully loading after a Home Assistant restart. Both issues were reproduced and verified on a production HA 2025.10.3 instance with the integration running inside a Docker bridge network.

---

## Bug 1: `ikea_bulb_device_set` crashes the hub event listener immediately after setup

### Root cause

In `light.py`, `ikea_bulb_device_set` registers itself directly into the `hub_event_listener` device registry:

```python
# Before (line 397)
hub_event_listener.register(self.unique_id, self)
```

All other entities (via `base_classes.py`) register a `registry_entry` wrapper:

```python
hub_event_listener.register(id, registry_entry(self))
```

When `sync_all_device_areas()` iterates the device registry and calls `registry_entry.entity`, it works for all normal entities (because their registry value is a `registry_entry` object with an `.entity` property). But for `ikea_bulb_device_set`, the registry value *is* the entity itself — a `LightEntity` subclass with no `.entity` attribute — causing an immediate `AttributeError`.

### Observed log errors

```
ERROR [custom_components.dirigera_platform.hub_event_listener] Failed to sync area for device 992c7af5-...: 'ikea_bulb_device_set' object has no attribute 'entity'
ERROR [custom_components.dirigera_platform.hub_event_listener] Failed to sync area for device e41e7d13-...: 'ikea_bulb_device_set' object has no attribute 'entity'
ERROR [custom_components.dirigera_platform.hub_event_listener] Failed to sync area for device 10025c83-...: 'ikea_bulb_device_set' object has no attribute 'entity'
WARNING [custom_components.dirigera_platform.hub_event_listener] Failed to create listener or listener exited, will sleep 10 seconds before retrying
```

This crash happens on every startup that has bulbs grouped in a device set. Once the listener dies, the integration enters a broken state and all subsequent device polling fails.

### Fix

```python
# After (light.py line 397)
hub_event_listener.register(self.unique_id, registry_entry(self))
```

`registry_entry` is already imported in `light.py` from `.hub_event_listener`, so no import changes are needed.

---

## Bug 2: `async_setup_entry` does not handle connection failures gracefully

### Root cause

`async_setup_entry` calls `make_devices()` with no exception handling. If the hub is temporarily unreachable during HA startup (e.g., brief network unavailability in Docker bridge environments, hub booting up, any transient OS-level network error), the `requests.exceptions.ConnectionError` or `OSError` propagates uncaught.

Home Assistant interprets this as a permanent failure and marks the entry as `setup_error` — which has **no automatic retry**. The correct HA pattern for transient connection failures is to raise `ConfigEntryNotReady`, which triggers HA's built-in exponential backoff retry mechanism.

### Observed behaviour

- Entry state: `setup_error` (permanent, no retry)
- Error in logs: `[Errno 101] Network unreachable` during `get_scenes` / `get_blinds` / `get_lights` calls within `make_devices`
- Manual reload required every time, sometimes 10–20 attempts needed before timing aligned with network availability

```
ERROR [homeassistant.config_entries] Error setting up entry IKEA Dirigera Hub : 192.168.0.80 for dirigera_platform
  File "custom_components/dirigera_platform/__init__.py", line 198, in async_setup_entry
  File "custom_components/dirigera_platform/ikea_gateway.py", line 50, in make_devices
  ...
OSError: [Errno 101] Network unreachable
```

Even with perfect hardware (both HA server and Dirigera hub wired to the same switch), Docker bridge containers can briefly get `ENETUNREACH` during early startup before routing tables and ARP caches stabilize.

### Fix

```python
from homeassistant.exceptions import ConfigEntryNotReady
import requests as _requests

# In async_setup_entry:
try:
    await platform.make_devices(hass, hass_data[CONF_IP_ADDRESS], hass_data[CONF_TOKEN])
except (_requests.exceptions.ConnectionError, OSError) as err:
    raise ConfigEntryNotReady(
        f"Cannot connect to IKEA Dirigera hub at {hass_data[CONF_IP_ADDRESS]}: {err}"
    ) from err
```

---

## Results after both fixes

Tested on HA 2025.10.3, `dirigera_platform` installed via HACS, Dirigera hub at 192.168.0.80, HA running in Docker bridge network:

| Scenario | Before | After |
|---|---|---|
| Integration state after reload | `setup_error` (no retry) | `loaded` in ~10s |
| `ikea_bulb_device_set` AttributeError | Present on every startup | Gone |
| `Failed to create listener` | Triggered every startup | Gone |
| Polling errors on `Temperatura` sensor | Every 60s after startup | None |
| Manual reloads needed | ~20 | 0 |

The integration now loads cleanly on first attempt. If a transient connection failure occurs (e.g., at container startup), HA retries automatically instead of requiring manual intervention.

---

## Files changed

- `custom_components/dirigera_platform/light.py` — 1 line changed
- `custom_components/dirigera_platform/__init__.py` — 7 lines added