### PR TITLE
Fix: guard color_mode writes against unsupported modes

### DIFF
--- a/custom_components/dirigera_platform/hub_event_listener.py
+++ b/custom_components/dirigera_platform/hub_event_listener.py
@@ -326,12 +326,16 @@ class hub_event_listener(threading.Thread):
                 except Exception as ex:
                     logger.warning(f"Scene action: failed to set {key} on {device_id}: {ex}")
 
-            # Update color_mode based on scene attributes
-            if updated and hasattr(entity, '_color_mode'):
-                if "colorHue" in attributes or "colorSaturation" in attributes:
+            # Update color_mode based on scene attributes.
+            # Only apply a mode the entity actually supports — Dirigera scene
+            # actions can include colorHue/colorSaturation/colorTemperature for
+            # devices that don't support those modes (e.g. Tradfri Driver).
+            if updated and hasattr(entity, '_color_mode') and hasattr(entity, '_supported_color_modes'):
+                supported = entity._supported_color_modes or []
+                if ("colorHue" in attributes or "colorSaturation" in attributes) and ColorMode.HS in supported:
                     entity._color_mode = ColorMode.HS
                     logger.debug(f"Scene action: set color_mode to HS for {device_id}")
-                elif "colorTemperature" in attributes:
+                elif "colorTemperature" in attributes and ColorMode.COLOR_TEMP in supported:
                     entity._color_mode = ColorMode.COLOR_TEMP
                     logger.debug(f"Scene action: set color_mode to COLOR_TEMP for {device_id}")
 
@@ -602,11 +606,15 @@ class hub_event_listener(threading.Thread):
                         logger.warn(f"Failed to set attribute key: {key} converted to {key_attr} on device: {id}")
                         logger.warn(ex)
                                 
-                # Update color_mode for lights when color attributes change
-                if device_type == "light" and hasattr(entity, '_color_mode'):
-                    if "colorHue" in attributes or "colorSaturation" in attributes:
+                # Update color_mode for lights when color attributes change.
+                # Guard with _supported_color_modes so we never set a mode the
+                # entity cannot report (e.g. Tradfri Driver is brightness-only
+                # but the hub may still emit colorHue/colorSaturation keys).
+                if device_type == "light" and hasattr(entity, '_color_mode') and hasattr(entity, '_supported_color_modes'):
+                    supported = entity._supported_color_modes or []
+                    if ("colorHue" in attributes or "colorSaturation" in attributes) and ColorMode.HS in supported:
                         entity._color_mode = ColorMode.HS
-                    elif "colorTemperature" in attributes:
+                    elif "colorTemperature" in attributes and ColorMode.COLOR_TEMP in supported:
                         entity._color_mode = ColorMode.COLOR_TEMP
 
                 # Lights behave odd with hubs when setting attribute one event is generated which

--- a/custom_components/dirigera_platform/light.py
+++ b/custom_components/dirigera_platform/light.py
@@ -316,7 +316,7 @@ class ikea_bulb(LightEntity):
                 await self.hass.async_add_executor_job(self._json_data.set_light_level,self.light_level)
                 self._ignore_update = True 
 
-            if ATTR_COLOR_TEMP_KELVIN in kwargs:
+            if ATTR_COLOR_TEMP_KELVIN in kwargs and ColorMode.COLOR_TEMP in self._supported_color_modes:
                 # color temp requested
                 logger.debug("Request to set color temp...")
                 ct = kwargs[ATTR_COLOR_TEMP_KELVIN]
@@ -331,7 +331,7 @@ class ikea_bulb(LightEntity):
                 self._color_mode = ColorMode.COLOR_TEMP
                 self._ignore_update = True
 
-            if ATTR_HS_COLOR in kwargs:
+            if ATTR_HS_COLOR in kwargs and ColorMode.HS in self._supported_color_modes:
                 logger.debug("Request to set color HS")
                 hs_tuple = kwargs[ATTR_HS_COLOR]
                 self._color_hue = hs_tuple[0]
@@ -485,23 +485,23 @@ class ikea_bulb_device_set(LightEntity):
                 await self.hass.async_add_executor_job(self.patch_command, {"lightLevel" : int((level / 255) * 100)})
                 self._controller._ignore_update = True 
 
-            if ATTR_COLOR_TEMP_KELVIN in kwargs:
+            if ATTR_COLOR_TEMP_KELVIN in kwargs and ColorMode.COLOR_TEMP in self._controller.supported_color_modes:
                 # color temp requested
                 # If request is white then brightness is passed
                 logger.debug("Request to device_set set color temp...")
                 ct = kwargs[ATTR_COLOR_TEMP_KELVIN]
                 logger.debug("Set CT : {}".format(ct))
                 await self.hass.async_add_executor_job(self.patch_command, {"colorTemperature" : ct})
-                self._controller._ignore_update = True 
+                self._controller._ignore_update = True
 
-            if ATTR_HS_COLOR in kwargs:
+            if ATTR_HS_COLOR in kwargs and ColorMode.HS in self._controller.supported_color_modes:
                 logger.debug("Request to set color HS device_set")
                 hs_tuple = kwargs[ATTR_HS_COLOR]
                 self._color_hue = hs_tuple[0]
                 self._color_saturation = hs_tuple[1] / 100
                 # Saturation is 0 - 1 at IKEA
-                self._controller._ignore_update = True 
-                
+                self._controller._ignore_update = True
+
                 await self.hass.async_add_executor_job(self.patch_command,{ "colorHue" : self._color_hue, "colorSaturation" : self._color_saturation})
 
         except Exception as ex:


### PR DESCRIPTION
## Summary
Fixes a `HomeAssistantError("... set to unsupported color mode hs, expected one of [<ColorMode.BRIGHTNESS: 'brightness'>]")` seen on brightness-only lights (e.g. TRÅDFRI Driver) after a scene activation or device state event. The error appears some time after HA startup and breaks `light.turn_on` until the integration is reloaded.

## Root cause
Four code paths wrote `_color_mode = ColorMode.HS` or `ColorMode.COLOR_TEMP` without checking the entity's `_supported_color_modes`:

- `light.ikea_bulb.async_turn_on` (sets HS/CT whenever those kwargs arrive — scenes can pass them to dim-only bulbs)
- `light.ikea_bulb_device_set.async_turn_on` (same, and also sent unsupported commands to the hub)
- `hub_event_listener` `deviceStateChanged` handler — introduced in d3a598d
- `hub_event_listener._apply_scene_actions` — introduced in 3dd51c5

Dirigera scene actions and `deviceStateChanged` events can include `colorHue` / `colorSaturation` / `colorTemperature` keys for devices that don't support those modes (scenes share a common payload shape across grouped devices). Once `_color_mode` was poisoned to `HS`, HA's core validation rejected the next `turn_on`.

## Fix
Guard each write and command path with a `ColorMode.X in supported_color_modes` check. Brightness-only entities now stay at `ColorMode.BRIGHTNESS` regardless of what the hub emits.

## Test plan
- [ ] Brightness-only bulb (TRÅDFRI Driver) in a scene with color bulbs: `light.turn_on` no longer raises after scene activation.
- [ ] Color bulb still honors HS and Color Temp commands, and `color_mode` reflects the last applied mode.
- [ ] Device-set group with mixed capabilities: color is applied only to color-capable members, brightness-only members dim without error.
- [ ] No regression in existing scene color-mode updates for color-capable bulbs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)