### PR TITLE
fix: avoid duplicate battery sensor on MYGGSPRAY

### DIFF
--- a/custom_components/dirigera_platform/sensor.py
+++ b/custom_components/dirigera_platform/sensor.py
@@ -61,11 +61,21 @@ async def async_setup_entry(
     async_add_entities(light_sensor_entities)
 
     # Add battery sensors
+    # MYGGSPRAY exposes occupancySensor + lightSensor as a split-device sharing
+    # relation_id; both report battery. Emit the battery once, from the motion side.
+    motion_relation_ids = {
+        s._json_data.relation_id for s in platform.motion_sensors
+        if s._json_data.relation_id
+    }
     battery_sensors = []
     battery_sensors.extend([battery_percentage_sensor(x) for x in platform.motion_sensors])
     battery_sensors.extend([battery_percentage_sensor(x) for x in platform.open_close_sensors])
     battery_sensors.extend([battery_percentage_sensor(x) for x in platform.water_sensors])
-    battery_sensors.extend([battery_percentage_sensor(x) for x in platform.light_sensors if getattr(x,"battery_percentage",None) is not None])
+    battery_sensors.extend([
+        battery_percentage_sensor(x) for x in platform.light_sensors
+        if getattr(x, "battery_percentage", None) is not None
+        and x._json_data.relation_id not in motion_relation_ids
+    ])
     battery_sensors.extend([battery_percentage_sensor(x) for x in platform.environment_sensors if getattr(x,"battery_percentage",None) is not None])
     battery_sensors.extend([battery_percentage_sensor(x) for x in platform.blinds if getattr(x,"battery_percentage",None) is not None])
 


### PR DESCRIPTION
## Why

MYGGSPRAY is a split-device: the hub exposes it as two devices (`occupancySensor` + `lightSensor`) sharing the same `relation_id`, and **both halves report `battery_percentage`**. Because each half reaches the battery list independently in `sensor.py:async_setup_entry`, two `Battery Percentage` entities end up under the same HA device — leaving an unwanted `_2` duplicate.

## What

In the battery-sensor wiring, skip a `light_sensor` when its `relation_id` matches any registered `motion_sensor`. The motion side already owns the battery diagnostic, so the light side stays as illuminance only.

Standalone `lightSensor` devices (none ship today, but the data model allows them) keep their battery sensor — only the duplicated case is suppressed.

## Test

- Restart HA. Each MYGGSPRAY device should now expose a single `Battery Percentage` entity. Any pre-existing `*_battery_percentage_2` becomes orphaned in the entity registry; delete it from the device page.
- Other battery-bearing devices (motion, water, open/close, vindstyrka, blinds) are unchanged.