### PR TITLE
feat: emit battery diagnostic on dynamically discovered sensors

### DIFF
--- a/custom_components/dirigera_platform/device_discovery.py
+++ b/custom_components/dirigera_platform/device_discovery.py
@@ -142,6 +142,13 @@ class DeviceDiscoveryCoordinator:
             callback = self._platform_callbacks[platform]
             callback([entity])
 
+            # Sensor device types that also report battery_percentage
+            # produce a companion battery diagnostic at startup (see
+            # sensor.py:async_setup_entry). Mirror that here so devices
+            # added at runtime (e.g. a freshly paired BADRING) get the
+            # battery sensor without requiring a HA restart.
+            self._add_battery_companion(device_type, entity)
+
             # Mark as known
             self._known_device_ids.add(device_id)
             logger.info(f"Successfully discovered and added device: {device_id} ({device_data.get('attributes', {}).get('customName', 'unnamed')})")
@@ -274,6 +281,23 @@ class DeviceDiscoveryCoordinator:
             import traceback
             logger.error(traceback.format_exc())
             return None
+
+    def _add_battery_companion(self, device_type: str, primary_entity: Any) -> None:
+        """Emit a battery diagnostic alongside the primary entity for sensor
+        device types that report battery_percentage. lightSensor is excluded
+        on purpose: today's only lightSensor is MYGGSPRAY's split half, whose
+        battery is owned by the paired motionSensor."""
+        if device_type not in ("waterSensor", "motionSensor", "occupancySensor", "openCloseSensor"):
+            return
+        wrapper = getattr(primary_entity, "_device", None)
+        if wrapper is None or getattr(wrapper, "battery_percentage", None) is None:
+            return
+        sensor_cb = self._platform_callbacks.get("sensor")
+        if sensor_cb is None:
+            logger.debug("No 'sensor' callback registered, skipping battery companion")
+            return
+        from .base_classes import battery_percentage_sensor
+        sensor_cb([battery_percentage_sensor(wrapper)])
 
 
 # Global instance - will be initialized in __init__.py


### PR DESCRIPTION
## Why

When a battery-powered sensor (`waterSensor`, `motionSensor`, `occupancySensor`, `openCloseSensor`) is paired while Home Assistant is **already running**, the WebSocket-driven discovery path in `device_discovery.py` creates only the primary entity (e.g. the leak `binary_sensor` for BADRING). The companion `battery_percentage_sensor` that the static startup path emits in `sensor.py:async_setup_entry` is never created — so the battery diagnostic only appears on the next HA restart.

## What

After the primary entity is dispatched in `discover_device`, call a small helper `_add_battery_companion(device_type, entity)` that:

- only acts on the four sensor types that have a battery on the static path,
- reads the wrapper from `entity._device` and skips if `battery_percentage` is `None`,
- looks up the already-registered `"sensor"` platform callback and invokes it with a `battery_percentage_sensor(wrapper)`.

`lightSensor` is intentionally excluded — today's only `lightSensor` is MYGGSPRAY's split half, whose battery is owned by the paired `motionSensor` (matches the static-path behavior in [#27](https://github.com/nrbrt/dirigera_platform/pull/27) once that lands; standalone or before that PR, it still avoids producing a duplicate when the motion sibling arrives).

## Test

- With HA running, pair a new water/motion/open-close sensor on the IKEA app. Within seconds the device should appear in HA with **both** the primary entity and a `Battery Percentage` diagnostic — no restart needed.
- Existing devices (already known) and the static startup path are unaffected.